### PR TITLE
Linkedin bugfix for shares that in text contain # (number sign)

### DIFF
--- a/src/js/angular-socialshare.js
+++ b/src/js/angular-socialshare.js
@@ -185,7 +185,7 @@
         $scope.linkedinShare = function manageLinkedinShare(data) {
 
           $window.open(
-            'https://www.linkedin.com/shareArticle?mini=true&url=' + encodeURIComponent(data.url || $location.absUrl()) + '&title=' + encodeURI(data.text)
+            'https://www.linkedin.com/shareArticle?mini=true&url=' + encodeURIComponent(data.url || $location.absUrl()) + '&title=' + encodeURIComponent(data.text)
             , 'sharer', 'toolbar=0,status=0,width=' + data.popupWidth + ',height=' + data.popupHeight);
         };
 


### PR DESCRIPTION
When content that contains # is shared to linkedin all the text after and including # is stripped.