### PR TITLE
Email body should be encoded

### DIFF
--- a/lib/angular-socialshare.js
+++ b/lib/angular-socialshare.js
@@ -526,7 +526,7 @@
 
       if (attrs.socialshareBody) {
 
-        urlString += 'body=' + attrs.socialshareBody;
+        urlString += 'body=' + encodeURIComponent(attrs.socialshareBody);
       }
 
       if (attrs.socialshareSubject) {


### PR DESCRIPTION
Add encodeURIComponent() to email body, same as for the other parameters.