### PR TITLE
Add missing space between text and URL on WhatsApp sharing

### DIFF
--- a/lib/angular-socialshare.js
+++ b/lib/angular-socialshare.js
@@ -788,7 +788,7 @@
     }
     , manageWhatsappShare = function manageWhatsappShare($window, attrs, element) {
 
-      var href = 'whatsapp://send?text=' + encodeURIComponent(attrs.socialshareText) + encodeURIComponent(attrs.socialshareUrl || $window.location.href);
+      var href = 'whatsapp://send?text=' + encodeURIComponent(attrs.socialshareText) + '%0A' + encodeURIComponent(attrs.socialshareUrl || $window.location.href);
 
       element.attr('href', href);
       element.attr('target', '_top');


### PR DESCRIPTION
This adds a space (actually a newline) between the text and the URL for WhatsApp sharing. Before, the text and the URL were together:
```
MY TEXThttp://myurl.com
```
The URL was interpreted as normal text by WhatsApp (`TEXThttp://myurl.com`). Now they have a newline in between:
```
MY TEXT
http://myurl.com
```
And also WhatsApp shows the preview for the URL now since the URL is correct.
