### PR TITLE
updated whats app href section

### DIFF
--- a/lib/angular-socialshare.js
+++ b/lib/angular-socialshare.js
@@ -788,7 +788,7 @@
     }
     , manageWhatsappShare = function manageWhatsappShare($window, attrs, element) {
 
-      var href = 'whatsapp://send?text=' + encodeURIComponent(attrs.socialshareText) + '%0A' + encodeURIComponent(attrs.socialshareUrl || $window.location.href);
+      var href = 'https://api.whatsapp.com/send?text=' + encodeURIComponent(attrs.socialshareText) + '%0A' + encodeURIComponent(attrs.socialshareUrl || $window.location.href);
 
       element.attr('href', href);
       element.attr('target', '_top');


### PR DESCRIPTION
earlier href section  'whatsapp://send?text=' was giving an error saying 
:8080/#!/project/marathon-nexzone:1 Failed to launch 'whatsapp://send?text=Milhomes%20No%20Brokerage%20Charges%2C%20We%20Sort%2C%20You%20Choose!%0Ahttps%3A%2F%2Fmilhomes.in%2Fproject%2Fgolf-meadows-godrej-city' because the scheme does not have a registered handler.

I did update the href section from  'whatsapp://send?text=' to 'https://api.whatsapp.com/send?text=', the code did work and i was able to get redirected to whats app to share my desired link.